### PR TITLE
Library fails if no fragments are present.

### DIFF
--- a/library/src/main/java/com/pchmn/rxsocialauth/auth/RxFacebookAuth.java
+++ b/library/src/main/java/com/pchmn/rxsocialauth/auth/RxFacebookAuth.java
@@ -111,7 +111,7 @@ public class RxFacebookAuth {
 
         // prevent fragment manager already executing transaction
         int stackCount = fragmentManager.getBackStackEntryCount();
-        if( fragmentManager.getFragments() != null )
+        if( fragmentManager.getFragments() != null && !fragmentManager.getFragments().isEmpty() )
             fragmentManager = fragmentManager.getFragments().get( stackCount > 0 ? stackCount-1 : stackCount ).getChildFragmentManager();
 
         RxFacebookAuthFragment rxFacebookAuthFragment = (RxFacebookAuthFragment)

--- a/library/src/main/java/com/pchmn/rxsocialauth/auth/RxGoogleAuth.java
+++ b/library/src/main/java/com/pchmn/rxsocialauth/auth/RxGoogleAuth.java
@@ -119,7 +119,7 @@ public class RxGoogleAuth {
 
         // prevent fragment manager already executing transaction
         int stackCount = fragmentManager.getBackStackEntryCount();
-        if( fragmentManager.getFragments() != null )
+        if( fragmentManager.getFragments() != null && !fragmentManager.getFragments().isEmpty() )
             fragmentManager = fragmentManager.getFragments().get( stackCount > 0 ? stackCount-1 : stackCount ).getChildFragmentManager();
 
         RxGoogleAuthFragment rxGoogleAuthFragment = (RxGoogleAuthFragment)

--- a/library/src/main/java/com/pchmn/rxsocialauth/smartlock/RxSmartLockPasswords.java
+++ b/library/src/main/java/com/pchmn/rxsocialauth/smartlock/RxSmartLockPasswords.java
@@ -80,7 +80,7 @@ public class RxSmartLockPasswords {
 
         // prevent fragment manager already executing transaction
         int stackCount = fragmentManager.getBackStackEntryCount();
-        if( fragmentManager.getFragments() != null )
+        if( fragmentManager.getFragments() != null && !fragmentManager.getFragments().isEmpty() )
             fragmentManager = fragmentManager.getFragments().get( stackCount > 0 ? stackCount-1 : stackCount ).getChildFragmentManager();
 
         RxSmartLockPasswordsFragment rxSmartLockPasswordsFragment = (RxSmartLockPasswordsFragment)


### PR DESCRIPTION
If the app architecture contains only activities, not fragments, the list of fragments will be empty, hence get(0) will cause the library to produce an error. 

If the list of fragments is empty, the main fragment manager should be used instead.