### PR TITLE
Fix build.gradle dependency in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ In your app level build.gradle :
 
 ```java
 dependencies {
-    compile 'com.github.pchmn:RxSocialAuth:2.0.1-beta'
+    implementation 'com.github.pchmn:RxSocialAuth:v2.0.1-beta'
 }
 ```
 


### PR DESCRIPTION
Version 2.0.1 is registered as `v2.0.1-beta` in jitpack and not `2.0.1-beta`

Also use `implementation` instead of `compile` to comply with gradle 3.0.0